### PR TITLE
Add erb gem to fix Ruby 3.4 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-
+gem 'erb'
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Synchronize with https://pages.github.com/versions


### PR DESCRIPTION
Problem  #46 

When running (bundle exec jekyll serve) with Ruby 3.4.5 on Arch Linux, Jekyll fails with:

cannot load such file -- erb (LoadError)

Solution
Added (gem 'erb') to the Gemfile to explicitly declare the dependency.

While erb is a default gem in Ruby 3.4+, explicitly declaring it in the Gemfile ensures Jekyll can properly load it across different Ruby installations and environments.